### PR TITLE
Private storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ target/
 
 # User uploaded files
 /media/uploads
+/private-media/uploads

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Some (not all) notable directories and files:
   - `static/` - Static files JavaScript, CSS, and image files.
   - `templates/` - Admin and app templates.
   - `constants.py` - File types accepted by Dropzone.js and form validation
-- `private-media/` - Directory where user files are uploaded
+- `private-media/` - Directory where user files are uploaded. Only accessible to administrators.
 - `src/` - Source files for static JavaScript and CSS.
 - `tests/` - Django project directory.
   - `settings/` - Settings files for each environment, but most customization should be in secrets.json.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Some (not all) notable directories and files:
   - `static/` - Static files JavaScript, CSS, and image files.
   - `templates/` - Admin and app templates.
   - `constants.py` - File types accepted by Dropzone.js and form validation
-- `media/` - Directory where user files are uploaded
+- `private-media/` - Directory where user files are uploaded
 - `src/` - Source files for static JavaScript and CSS.
 - `tests/` - Django project directory.
   - `settings/` - Settings files for each environment, but most customization should be in secrets.json.

--- a/keeper/migrations/0002_auto_20180507_1336.py
+++ b/keeper/migrations/0002_auto_20180507_1336.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import private_storage.fields
+import keeper.validators
+import keeper.models
+import private_storage.storage.files
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('keeper', '0001_squashed_0017_auto_20151215_1637'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='accession',
+            name='first_name',
+            field=models.CharField(max_length=100),
+        ),
+        migrations.AlterField(
+            model_name='accession',
+            name='last_name',
+            field=models.CharField(max_length=100),
+        ),
+        migrations.AlterField(
+            model_name='file',
+            name='file',
+            field=private_storage.fields.PrivateFileField(storage=private_storage.storage.files.PrivateFileSystemStorage(), upload_to=keeper.models.file_upload_location, validators=[keeper.validators.validate_file_type]),
+        ),
+    ]

--- a/keeper/models.py
+++ b/keeper/models.py
@@ -2,6 +2,8 @@ import os
 
 from django.db import models
 
+from private_storage.fields import PrivateFileField
+
 from constants import ACCEPTED_FILE_TYPES
 from validators import validate_file_type
 
@@ -66,7 +68,7 @@ def file_upload_location(instance, filename):
 
 
 class File(models.Model):
-    file = models.FileField(upload_to=file_upload_location, validators=[validate_file_type])
+    file = PrivateFileField(upload_to=file_upload_location, validators=[validate_file_type])
     accession = models.ForeignKey('Accession')
     file_description = models.TextField(blank=True)
     content_type = models.CharField(max_length=255, blank=True)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,5 @@
 django-parsley==0.6
+django-private-storage==2.0
 django-recaptcha==1.0.4
 mysqlclient==1.3.7
 python-magic==0.4.10

--- a/tests/settings/base.py
+++ b/tests/settings/base.py
@@ -50,13 +50,13 @@ ALLOWED_HOSTS = get_secret('ALLOWED_HOSTS')
 
 INSTALLED_APPS = (
     'keeper',
+    'private_storage',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'private_storage',
     'parsley',
     'captcha',
 )

--- a/tests/settings/base.py
+++ b/tests/settings/base.py
@@ -9,6 +9,10 @@ BASE_DIR = Path(__file__).ancestor(3)
 MEDIA_ROOT = BASE_DIR.child('media')
 MEDIA_URL = '/media/'
 
+# Settings for Django Private Storage
+PRIVATE_STORAGE_ROOT = BASE_DIR.child('private-media')
+PRIVATE_STORAGE_AUTH_FUNCTION = 'private_storage.permissions.allow_staff'
+
 # Gets the site root (same level that project, apps, and templates lives on)
 SITE_ROOT = os.path.realpath(os.path.dirname(os.path.dirname(__file__)))
 
@@ -52,6 +56,7 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'private_storage',
     'parsley',
     'captcha',
 )

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -20,8 +20,10 @@ from django.conf.urls import include, url
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
+import private_storage.urls
 
 urlpatterns = [
     url(r'', include('keeper.urls', namespace='keeper', app_name='keeper')),
     url(r'^admin/', include(admin.site.urls)),
+    url('^private-media/', include(private_storage.urls)),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Adds django-private-storage app and uses its file type instead of Django File. This required a database migration. Details for dev server will be sent separately.